### PR TITLE
Using sh instead of bash to apply changes

### DIFF
--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -58,7 +58,7 @@ export function isBatteryPlugged() {
 
 export function _execSwitch(profile, c1, c2) {
     // exec switch
-    Util.spawn(['/bin/bash', '-c', COMMAND_TO_SWITCH_GPU_PROFILE
+    Util.spawn(['/bin/sh', '-c', COMMAND_TO_SWITCH_GPU_PROFILE
         .replace("{profile}", profile)
         .replace("{choice1}", c1)
         .replace("{choice2}", c2)


### PR DESCRIPTION
On some Linux Distributions such as my NixOS install /bin/bash isn't aviable. Because `sh` is the standard shell for POSIX-Compliant systems it'll make sense to use it instead.

I tested the changes and they work on my machine.