### PR TITLE
Modified detection of current profile directly using 'envycontrol --query'

### DIFF
--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -16,20 +16,8 @@ const GPU_PROFILE_NVIDIA = "nvidia"
 
 
 export function getCurrentProfile() {
-    // init files needed
-    const black_list_file = Gio.File.new_for_path(BLACKLIST_PATH);
-    const udev_integrated_file = Gio.File.new_for_path(UDEV_INTEGRATED_PATH);
-    const xorg_file = Gio.File.new_for_path(XORG_PATH);
-    const modeset_file = Gio.File.new_for_path(MODESET_PATH);
-
-    // check in which mode you are
-    if (black_list_file.query_exists(null) && udev_integrated_file.query_exists(null)) {
-        return GPU_PROFILE_INTEGRATED;
-    } else if (xorg_file.query_exists(null) && modeset_file.query_exists(null)) {
-        return GPU_PROFILE_NVIDIA;
-    } else {
-        return GPU_PROFILE_HYBRID;
-    }
+    let profile = GLib.spawn_command_line_sync("envycontrol --query")[1].toString().trim();
+    return profile;
 }
 
 export function capitalizeFirstLetter(string) {

--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -1,4 +1,5 @@
 import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 
 const BLACKLIST_PATH = '/etc/modprobe.d/blacklist-nvidia.conf';

--- a/metadata.json
+++ b/metadata.json
@@ -10,5 +10,5 @@
   "url": "https://github.com/LorenzoMorelli/GPU_profile_selector",
   "uuid": "GPU_profile_selector@lorenzo9904.gmail.com",
   "settings-schema": "org.gnome.shell.extensions.GPU_profile_selector",
-  "version": 20
+  "version": 21
 }

--- a/ui/AttachedToBatteryView.js
+++ b/ui/AttachedToBatteryView.js
@@ -13,6 +13,7 @@ class AttachedToBatteryToggle extends QuickSettings.QuickMenuToggle {
             title: Utility.capitalizeFirstLetter(Utility.getCurrentProfile()),
             iconName: 'selection-mode-symbolic',
             toggleMode: false, // disable the possibility to click the button
+            checked: true,
         });
         this.all_settings = extensionObject.getSettings();
         


### PR DESCRIPTION
I modified how the current profile is checked, using "envycontrol --query" instead of verifying the presence of specific files.
I had some issues with the latter method on Fedora 41.
For example, even though "envycontrol --query" returned the "integrated" profile, the GNOME extension always reported "hybrid" because the file "/lib/udev/rules.d/50-remove-nvidia.rules" was not present.
Using "envycontrol --query" directly resolves the issue.
I also added "checked: true" to the quick setting button because imo it better shows that selected profile is active (there is always an active profile).