### PR TITLE
Enhance GPU profile detection and update metadata for improved clarit…

### DIFF
--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -1,4 +1,5 @@
 import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 
 const BLACKLIST_PATH = '/etc/modprobe.d/blacklist-nvidia.conf';
@@ -13,22 +14,27 @@ const EXTENSION_ICON_FILE_NAME = '/img/icon.png';
 const GPU_PROFILE_INTEGRATED = "integrated"
 const GPU_PROFILE_HYBRID = "hybrid"
 const GPU_PROFILE_NVIDIA = "nvidia"
-
+const GPU_PROFILE_UNKNOWN = "unknown"
 
 export function getCurrentProfile() {
-    // init files needed
-    const black_list_file = Gio.File.new_for_path(BLACKLIST_PATH);
-    const udev_integrated_file = Gio.File.new_for_path(UDEV_INTEGRATED_PATH);
-    const xorg_file = Gio.File.new_for_path(XORG_PATH);
-    const modeset_file = Gio.File.new_for_path(MODESET_PATH);
+    try {
+        const [success, stdout, stderr, exitCode] = GLib.spawn_command_line_sync("envycontrol --query");
 
-    // check in which mode you are
-    if (black_list_file.query_exists(null) && udev_integrated_file.query_exists(null)) {
-        return GPU_PROFILE_INTEGRATED;
-    } else if (xorg_file.query_exists(null) && modeset_file.query_exists(null)) {
-        return GPU_PROFILE_NVIDIA;
-    } else {
-        return GPU_PROFILE_HYBRID;
+        if (success && exitCode === 0) {
+            const profileString = stdout.toString().trim().toLowerCase();
+
+            if (profileString === GPU_PROFILE_INTEGRATED ||
+                profileString === GPU_PROFILE_HYBRID ||
+                profileString === GPU_PROFILE_NVIDIA) {
+                return profileString;
+            }
+        }
+
+        // If the command failed or returned an unexpected profile
+        return GPU_PROFILE_UNKNOWN;
+    } catch (e) {
+        // If there was an error running the command
+        return GPU_PROFILE_UNKNOWN;
     }
 }
 
@@ -44,11 +50,11 @@ export function isBatteryPlugged() {
 
     while (true) {
         const info = iter.next_file(null);
-    
+
         if (info == null) {
             break;
         }
-            
+
         if(info.get_name().includes("BAT")) {
             return true;
         }

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "A GNOME Shell extension that provides an easy way to switch between GPU profiles on Nvidia Optimus systems (e.g., laptops with Intel + Nvidia or AMD + Nvidia configurations) in just a few clicks. Requires envycontrol (https://github.com/geminis3/envycontrol) to function.",
+  "description": "A GNOME Shell extension that provides an easy way to switch between GPU profiles on Nvidia Optimus systems (e.g., laptops with Intel + Nvidia or AMD + Nvidia configurations) in just a few clicks. Requires envycontrol (https://github.com/geminis3/envycontrol).",
   "name": "GPU Profile Selector",
   "shell-version": [
     "45",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
-  "description": "You need to install envycontrol(https://github.com/geminis3/envycontrol) to make this extension work. This is a simple gnome-shell extension which provides a simple way to switch between GPU profiles on Nvidia Optimus systems (i.e laptops with Intel + Nvidia or AMD + Nvidia configurations) in a few clicks.",
-  "name": "GPU profile selector",
+  "description": "A GNOME Shell extension that provides an easy way to switch between GPU profiles on Nvidia Optimus systems (e.g., laptops with Intel + Nvidia or AMD + Nvidia configurations) in just a few clicks. Requires envycontrol (https://github.com/geminis3/envycontrol) to function.",
+  "name": "GPU Profile Selector",
   "shell-version": [
     "45",
     "46",
@@ -10,5 +10,12 @@
   "url": "https://github.com/LorenzoMorelli/GPU_profile_selector",
   "uuid": "GPU_profile_selector@lorenzo9904.gmail.com",
   "settings-schema": "org.gnome.shell.extensions.GPU_profile_selector",
-  "version": 20
+  "version": 21,
+  "author": "Lorenzo Morelli",
+  "contributors": [
+    "Lorenzo Morelli",
+    "Guilhem Jéhanno",
+    "ihpled"
+  ],
+  "license": "GPL-3.0-or-later"
 }

--- a/ui/AttachedToBatteryView.js
+++ b/ui/AttachedToBatteryView.js
@@ -11,18 +11,18 @@ class AttachedToBatteryToggle extends QuickSettings.QuickMenuToggle {
     _init(extensionObject) {
         const currentProfile = Utility.getCurrentProfile();
         super._init({
-            title: currentProfile === Utility.GPU_PROFILE_UNKNOWN ?
-                   'GPU Profile' :
-                   Utility.capitalizeFirstLetter(currentProfile),
+            title: currentProfile === Utility.GPU_PROFILE_UNKNOWN
+                ? 'GPU Profile'
+                : Utility.capitalizeFirstLetter(currentProfile),
             iconName: 'selection-mode-symbolic',
             toggleMode: false, // disable the possibility to click the button
             checked: true,
         });
         this.all_settings = extensionObject.getSettings();
 
-        const headerTitle = currentProfile === Utility.GPU_PROFILE_UNKNOWN ?
-                           'Select GPU Profile' :
-                           Utility.capitalizeFirstLetter(currentProfile);
+        const headerTitle = currentProfile === Utility.GPU_PROFILE_UNKNOWN
+            ? 'Select GPU Profile'
+            : Utility.capitalizeFirstLetter(currentProfile);
 
         // This function is unique to this class. It adds a nice header with an icon, title and optional subtitle.
         this.menu.setHeader('selection-mode-symbolic', headerTitle, 'Choose a GPU mode');
@@ -48,8 +48,10 @@ class AttachedToBatteryToggle extends QuickSettings.QuickMenuToggle {
 
         // Add an entry-point for more settings
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-        const settingsItem = this.menu.addAction('More Settings',
-            () => extensionObject.openPreferences());
+        const settingsItem = this.menu.addAction(
+            'More Settings',
+            () => extensionObject.openPreferences()
+        );
 
         // Ensure the settings are unavailable when the screen is locked
         settingsItem.visible = Main.sessionMode.allowSettings;

--- a/ui/AttachedToBatteryView.js
+++ b/ui/AttachedToBatteryView.js
@@ -9,16 +9,24 @@ import * as Utility from '../lib/Utility.js';
 export const AttachedToBatteryToggle = GObject.registerClass(
 class AttachedToBatteryToggle extends QuickSettings.QuickMenuToggle {
     _init(extensionObject) {
+        const currentProfile = Utility.getCurrentProfile();
         super._init({
-            title: Utility.capitalizeFirstLetter(Utility.getCurrentProfile()),
+            title: currentProfile === Utility.GPU_PROFILE_UNKNOWN ?
+                   'GPU Profile' :
+                   Utility.capitalizeFirstLetter(currentProfile),
             iconName: 'selection-mode-symbolic',
             toggleMode: false, // disable the possibility to click the button
+            checked: true,
         });
         this.all_settings = extensionObject.getSettings();
-        
+
+        const headerTitle = currentProfile === Utility.GPU_PROFILE_UNKNOWN ?
+                           'Select GPU Profile' :
+                           Utility.capitalizeFirstLetter(currentProfile);
+
         // This function is unique to this class. It adds a nice header with an icon, title and optional subtitle.
-        this.menu.setHeader('selection-mode-symbolic', Utility.capitalizeFirstLetter(Utility.getCurrentProfile()), 'Choose a GPU mode');
-        
+        this.menu.setHeader('selection-mode-symbolic', headerTitle, 'Choose a GPU mode');
+
         // add a sections of items to the menu
         this._itemsSection = new PopupMenu.PopupMenuSection();
         this._itemsSection.addAction('Nvidia', () => {
@@ -42,7 +50,7 @@ class AttachedToBatteryToggle extends QuickSettings.QuickMenuToggle {
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
         const settingsItem = this.menu.addAction('More Settings',
             () => extensionObject.openPreferences());
-            
+
         // Ensure the settings are unavailable when the screen is locked
         settingsItem.visible = Main.sessionMode.allowSettings;
         this.menu._settingsActions[extensionObject.uuid] = settingsItem;

--- a/ui/TopBarView.js
+++ b/ui/TopBarView.js
@@ -14,7 +14,7 @@ const ICON_HYBRID_FILE_NAME = '/img/hybrid_icon_plain.svg';
 
 
 export const TopBarView = GObject.registerClass(
-class TopBarView extends PanelMenu.Button {  
+class TopBarView extends PanelMenu.Button {
     _init(extensionObject) {
         super._init(0);
         this._all_settings = extensionObject.getSettings();
@@ -104,12 +104,18 @@ class TopBarView extends PanelMenu.Button {
                 gicon : Gio.icon_new_for_string(this._extension_path + ICON_HYBRID_FILE_NAME),
                 style_class: 'system-status-icon',
             });
-        } else {
+        } else if(gpu_profile === Utility.GPU_PROFILE_NVIDIA) {
             this.integrated_menu_item.remove_child(this.icon_selector);
             this.hybrid_menu_item.remove_child(this.icon_selector);
             this.nvidia_menu_item.add_child(this.icon_selector);
             this.icon_top = new St.Icon({
                 gicon : Gio.icon_new_for_string(this._extension_path + ICON_NVIDIA_FILE_NAME),
+                style_class: 'system-status-icon',
+            });
+        } else {
+            // Default state for unknown profile
+            this.icon_top = new St.Icon({
+                gicon : Gio.icon_new_for_string(this._extension_path + Utility.EXTENSION_ICON_FILE_NAME),
                 style_class: 'system-status-icon',
             });
         }


### PR DESCRIPTION
Based on @ihpled work, I added what you asked him

Like when the extension is freshly installed or if envycontrol isn't available/working properly, it will display a generic "GPU Profile" label instead of an empty one / Handles error cases by showing an "unknown" state rather than breaking and UI elements will be properly initialized even when the current GPU profile can't be determined

Enjoy :)