### PR TITLE
Enabled Gnome 49 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "gettext-domain": "GPU_profile_selector",
   "url": "https://github.com/LorenzoMorelli/GPU_profile_selector",


### PR DESCRIPTION
Only metadata changes were required. Tested on arch linux (gnome-shell 49.0.2)