### PR TITLE
Fixed Gjs warning

### DIFF
--- a/lib/Utility.js
+++ b/lib/Utility.js
@@ -21,7 +21,8 @@ export function getCurrentProfile() {
         const [success, stdout, stderr, exitCode] = GLib.spawn_command_line_sync("envycontrol --query");
 
         if (success && exitCode === 0) {
-            const profileString = stdout.toString().trim().toLowerCase();
+            const textDecoder = new TextDecoder();
+            const profileString = textDecoder.decode(stdout).trim().toLowerCase();
 
             if (profileString === GPU_PROFILE_INTEGRATED ||
                 profileString === GPU_PROFILE_HYBRID ||


### PR DESCRIPTION
Tested on arch linux (gnome-shell 49.0.2).

Using the recommended js method to parse Uint8Array as described by the warning below.
Gjs-WARNING **: 02:10:33.069: Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to use TextDecoder.